### PR TITLE
Add Gitlab provider

### DIFF
--- a/src/Regex/Supplier/Gitlab.php
+++ b/src/Regex/Supplier/Gitlab.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * This file is part of CaptainHook Secrets.
+ *
+ * (c) Sebastian Feldmann <sf@sebastian-feldmann.info>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace CaptainHook\Secrets\Regex\Supplier;
+
+use CaptainHook\Secrets\Regex\Supplier;
+
+/**
+ * Gitlab regex
+ *
+ * Provides the regex to find Gitlab secrets.
+ *
+ * @package CaptainHook-Secrets
+ * @since   Class available since Release 0.9.6
+ */
+final class Gitlab implements Supplier {
+
+	/**
+	 * Sourced from https://github.com/gitlabhq/gitlabhq/blob/master/gems/gitlab-secret_detection/lib/gitleaks.toml#L4-L51
+	 * @return string[]
+	 */
+	public function patterns(): array {
+		return [
+			// GitLab Personal Access Token
+			'#' . Util::OPTIONAL_QUOTE . '(glpat-[0-9a-zA-Z_\\-]{20})' . Util::OPTIONAL_QUOTE . '#',
+			// GitLab Pipeline Trigger Token
+			'#' . Util::OPTIONAL_QUOTE . '(glptt-[0-9a-zA-Z_\\-]{40})' . Util::OPTIONAL_QUOTE . '#',
+			// GitLab Runner Registration Token
+			'#' . Util::OPTIONAL_QUOTE . '(GR1348941[0-9a-zA-Z_\\-]{20})' . Util::OPTIONAL_QUOTE . '#',
+			// GitLab OAuth Application Secrets
+			'#' . Util::OPTIONAL_QUOTE . '(gloas-[0-9a-zA-Z_\\-]{64})' . Util::OPTIONAL_QUOTE . '#',
+			// GitLab Feed token
+			'#' . Util::OPTIONAL_QUOTE . '(glft-[0-9a-zA-Z_\\-]{20})' . Util::OPTIONAL_QUOTE . '#',
+			// GitLab Agent for Kubernetes token
+			'#' . Util::OPTIONAL_QUOTE . '(glagent-[0-9a-zA-Z_\\-]{50})' . Util::OPTIONAL_QUOTE . '#',
+			// GitLab Incoming email token
+			'#' . Util::OPTIONAL_QUOTE . '(glimt-[0-9a-zA-Z_\\-]{25})' . Util::OPTIONAL_QUOTE . '#',
+		];
+	}
+}

--- a/tests/Regex/Supplier/GitlabTest.php
+++ b/tests/Regex/Supplier/GitlabTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace CaptainHook\Secrets\Regex\Supplier;
+
+use CaptainHook\Secrets\Detector;
+use PHPUnit\Framework\TestCase;
+
+final class GitlabTest extends TestCase
+{
+	public function testDetectSecret(): void
+	{
+		$haystack = 'bar glpat-mBvGsDcJUvxvFZktWpzz baz';
+		$detector = Detector::create()->useSuppliers(new Gitlab());
+		$result   = $detector->detectIn($haystack);
+
+		$this->assertTrue($result->wasSecretDetected());
+		$this->assertCount(1, $result->matches());
+	}
+
+	public function testDontDetectSecret(): void
+	{
+		$haystack = 'bar glpat-mBvGsDcJUvx... gitlab glpat-15487234 glpat-mBvG{}_JUvxvFZktWpzz';
+		$detector = Detector::create()->useSuppliers(new Gitlab());
+		$result   = $detector->detectIn($haystack);
+
+		$this->assertFalse($result->wasSecretDetected());
+		$this->assertCount(0, $result->matches());
+	}
+}


### PR DESCRIPTION
I added a Gitlab provider to find Gitlab Secrets. 

The regex are sourced from this location: https://github.com/gitlabhq/gitlabhq/blob/master/gems/gitlab-secret_detection/lib/gitleaks.toml#L4-L51

Some things I was not sure about:

- The Doc of the provider file. Not sure what I should include there.
- I can extract common parts from the regex and create a method where you can input the variable parts (the prefix and the amount of chars). But I think doing it like this is easier to read.
- The test only tests for one of the regexes. I can add more, but the Github test also only tests for one regex.

Let me know what I can improve! 